### PR TITLE
Fix setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
         package_data={'boofuzz': ['web/templates/*', 'web/static/css/*', 'web/static/js/*']},
         install_requires=[
             'future', 'pyserial', 'pydot', 'tornado~=4.0',
-            'Flask~=1.0', 'impacket', 'colorama', 'attrs', 'click', 'psutil'],
+            'Flask~=1.0', 'impacket', 'colorama', 'attrs', 'click', 'psutil', 'ldap3==2.5.1'],
         extras_require={
             # This list is duplicated in tox.ini. Make sure to change both!
             'dev': ['check-manifest',


### PR DESCRIPTION
Impacket requires both ldap3 and ldapdomaindump, while ldapdomaindump requires ldap3==2.5.1.
Apparently ldap3 2.5.2 is installed before knowing of this requirement so the installation fails.

This should only be a temporary fix, we might want to consider removing impacket completely.
The only occurence of it is in `network_monitor.py` which is marked as depreciated.